### PR TITLE
enable multiple requests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 # app/main.py
+import logging
 import os
 
 from fastapi import FastAPI
@@ -8,6 +9,10 @@ from fastapi.requests import Request
 from fastapi.responses import FileResponse
 from fastapi.responses import JSONResponse
 
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+)
 from .config import settings
 from .models.db import init_models
 from .routers import items

--- a/app/main.py
+++ b/app/main.py
@@ -9,7 +9,7 @@ from fastapi.responses import FileResponse
 from fastapi.responses import JSONResponse
 
 from .config import settings
-from .models.db import Base, engine
+from .models.db import init_models
 from .routers import items
 
 app = FastAPI(
@@ -32,8 +32,8 @@ app.include_router(items.router)
 
 
 @app.on_event("startup")
-def on_startup():
-    Base.metadata.create_all(bind=engine)
+async def on_startup():
+    await init_models()
 
 
 @app.get("/")

--- a/app/models/db.py
+++ b/app/models/db.py
@@ -1,7 +1,14 @@
-from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 Base = declarative_base()
-engine = create_engine('sqlite:///data/app.db', echo=True)
-SessionLocal = sessionmaker(bind=engine)
+engine = create_async_engine('sqlite+aiosqlite:///data/app.db', echo=True)
+async_session = sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+async def init_models():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/app/models/openai_client.py
+++ b/app/models/openai_client.py
@@ -1,20 +1,22 @@
 import base64
 import os
 
+import aiofiles
 from openai import OpenAI
 
 client = OpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
 
 
-def encode_image_to_base64(path):
-    with open(path, "rb") as f:
-        return base64.b64encode(f.read()).decode("utf-8")
+async def encode_image_to_base64(path):
+    async with aiofiles.open(path, "rb") as f:
+        data = await f.read()
+    return base64.b64encode(data).decode("utf-8")
 
 
-def image_to_story(client, path):
-    base64_image = encode_image_to_base64(path)
+async def image_to_story(client, path):
+    base64_image = await encode_image_to_base64(path)
 
-    response = client.chat.completions.create(
+    response = await client.chat.completions.create(
         model="gpt-4o",
         messages=[
             {
@@ -37,10 +39,10 @@ def image_to_story(client, path):
     return response.choices[0].message.content
 
 
-def image_to_title(client, path):
-    base64_image = encode_image_to_base64(path)
+async def image_to_title(client, path):
+    base64_image = await encode_image_to_base64(path)
 
-    response = client.chat.completions.create(
+    response = await client.chat.completions.create(
         model="gpt-4o",
         messages=[
             {
@@ -63,9 +65,9 @@ def image_to_title(client, path):
     return response.choices[0].message.content
 
 
-def story_to_image(client, story):
+async def story_to_image(client, story):
     prompt = "Please draw a sketch for the provided story. The sketch should contain several scenes going one after another. Keep it in a simple schematic way. The story is:\n" + story
-    response = client.images.generate(
+    response = await client.images.generate(
         model="gpt-image-1",
         prompt=prompt,
         #quality="high",
@@ -77,16 +79,17 @@ def story_to_image(client, story):
     return image_url
 
 
-def modify_image(client, image_path, text=None):
+async def modify_image(client, image_path, text=None):
     prompt = "Generate from this sketch a story. try to seperate the frames with the arrows and do not change the number of frames. draw everything in a cartoony style. please do not change the number of frames. and make the least number of changes possible"
     if text:
         prompt += f"this is the text, make only the necessary changes: {text} but do not write the text on the picture"
 
-    response = client.images.edit(
+    async with aiofiles.open(image_path, "rb") as f:
+        image_bytes = await f.read()
+
+    response = await client.images.edit(
         model="gpt-image-1",
-        image=[
-            open(image_path, "rb"),
-        ],
+        image=[image_bytes],
         prompt=prompt,
         n=1,
         quality="high",

--- a/app/models/openai_client.py
+++ b/app/models/openai_client.py
@@ -83,13 +83,9 @@ async def modify_image(client, image_path, text=None):
     prompt = "Generate from this sketch a story. try to seperate the frames with the arrows and do not change the number of frames. draw everything in a cartoony style. please do not change the number of frames. and make the least number of changes possible"
     if text:
         prompt += f"this is the text, make only the necessary changes: {text} but do not write the text on the picture"
-
-    async with aiofiles.open(image_path, "rb") as f:
-        image_bytes = await f.read()
-
     response = await client.images.edit(
         model="gpt-image-1",
-        image=[image_bytes],
+        image=[open(image_path, "rb")],
         prompt=prompt,
         n=1,
         quality="high",

--- a/app/models/openai_client.py
+++ b/app/models/openai_client.py
@@ -1,10 +1,6 @@
 import base64
-import os
 
 import aiofiles
-from openai import OpenAI
-
-client = OpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
 
 
 async def encode_image_to_base64(path):

--- a/app/models/structures.py
+++ b/app/models/structures.py
@@ -205,19 +205,16 @@ class Story(Base):
 
                 overlay_bytes = base64.b64decode(base64_data)
                 overlay_image = PIL_Image.open(BytesIO(overlay_bytes)).convert("RGBA")
-                overlay_data = overlay_image.getdata()
                 new_data = []
-                for r, g, b, a in overlay_data:
-                    if r > 200 and g < 100 and b < 100:
-                        new_data.append((255, 255, 255, a))  # red → white
-                    else:
-                        new_data.append((r, g, b, a))
                 overlay_image.putdata(new_data)
                 base_width, base_height = base_image.size
                 overlay_width, overlay_height = overlay_image.size
-                x = (base_width - overlay_width) // 2
-                y = (base_height - overlay_height) // 2
-                base_image.paste(overlay_image, (x, y), overlay_image)
+                left = (overlay_width - base_width) // 2
+                top = (overlay_height - base_height) // 2
+                right = left + base_width
+                bottom = top + base_height
+                cropped_overlay = overlay_image.crop((left, top, right, bottom))
+                base_image.paste(cropped_overlay, (0, 0), cropped_overlay)
                 buffered = BytesIO()
                 base_image.save(buffered, format="PNG")
                 new_base64 = base64.b64encode(buffered.getvalue()).decode("utf-8")

--- a/app/models/structures.py
+++ b/app/models/structures.py
@@ -7,6 +7,7 @@ from io import BytesIO
 from typing import List, Dict
 
 from PIL import Image as PIL_Image
+from openai import AsyncOpenAI
 from sqlalchemy import Integer, select, update
 from sqlalchemy import create_engine, Column, String, DateTime, ForeignKey, Enum as SqlEnum, Text
 from sqlalchemy.ext.declarative import declarative_base
@@ -84,7 +85,7 @@ class Story(Base):
     userId = Column(String, ForeignKey('users.userId'))
     image_counter = Column(Integer, default=0)
 
-    images = relationship("Image", backref="story", cascade="all, delete-orphan")
+    images = relationship("Image", backref="story", cascade="all, delete-orphan", lazy="selectin")
 
     # --- Methods ---
 
@@ -133,32 +134,31 @@ class Story(Base):
         self.text = updated_text
         self.lastEdited = datetime.now(timezone.utc)
 
-    def update_images_by_text(self, new_text: str):
+    async def update_images_by_text(self, new_text: str):
         self.set_raw_text(new_text)
         raw_text = self.get_raw_text()
-        base64_image = self.generate_image_from_sketch_only(raw_text)
-        self.upload_image(base64_image)
-        self.update_story_name()
+        base64_image = await self.generate_image_from_sketch_only(raw_text)
+        await self.upload_image(base64_image)
+        await self.update_story_name()
 
-    def update_from_image_operations(self, image_operations: List[Dict]):
+    async def update_from_image_operations(self, image_operations: List[Dict]):
         operations = [ImageOperation.parse_image_operation(op) for op in image_operations]
-        self.execute_image_operations(operations)
-        self.update_story_name()
+        await self.execute_image_operations(operations)
+        await self.update_story_name()
 
     def set_story_name(self, story_name: str):
         self.name = story_name
         self.lastEdited = datetime.now(timezone.utc)
 
-    def update_story_name(self):
+    async def update_story_name(self):
         if self.name == "New Story":
-            from openai import OpenAI
-            client = OpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
+            client = AsyncOpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
             image_path = f"/etc/images/{self.userId}/{self.storyId}/{self.images[-1].imageId}.png"
             from ..models.openai_client import image_to_title
-            story_title = image_to_title(client, image_path)
+            story_title = await image_to_title(client, image_path)
             self.name = story_title
 
-    def upload_image(self, image_binary: str):
+    async def upload_image(self, image_binary: str):
         self.image_counter +=1
         image_id = f"img_{self.storyId}_{self.image_counter}"
         dir_path = f"/etc/images/{self.userId}/{self.storyId}"
@@ -181,16 +181,16 @@ class Story(Base):
         self.images.append(new_image)
         self.lastEdited = datetime.now(timezone.utc)
 
-    def execute_image_operation(self, image_operation: ImageOperation):
+    async def execute_image_operation(self, image_operation: ImageOperation):
         match image_operation.operation:
             case Operation.NO_CHANGE:
-                new_text = self.generate_no_change_text_string()
+                new_text = await self.generate_no_change_text_string()
                 self.set_formatted_text(new_text)
             case Operation.SKETCH_FROM_SCRATCH:
-                self.upload_image(image_operation.canvas_data)
-                base64_image = self.generate_image_from_sketch_only("from scratch and up to you.")
-                self.upload_image(base64_image)
-                new_text = self.generate_no_change_text_string()
+                await self.upload_image(image_operation.canvas_data)
+                base64_image = await self.generate_image_from_sketch_only("from scratch and up to you.")
+                await self.upload_image(base64_image)
+                new_text = await self.generate_no_change_text_string()
                 self.set_formatted_text(new_text)
             case Operation.SKETCH_ON_IMAGE:
                 base_image_path = f"/etc/images/{self.userId}/{self.storyId}/{image_operation.image_id}.png"
@@ -220,35 +220,32 @@ class Story(Base):
                 base_image.save(buffered, format="PNG")
                 new_base64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
                 data_uri = f"data:image/png;base64,{new_base64}"
-                self.upload_image(data_uri)
-                base64_image = self.generate_image_from_sketch_only()
-                self.upload_image(base64_image)
-                new_text = self.generate_no_change_text_string()
+                await self.upload_image(data_uri)
+                base64_image = await self.generate_image_from_sketch_only()
+                await self.upload_image(base64_image)
+                new_text = await self.generate_no_change_text_string()
                 self.set_formatted_text(new_text)
             case _:
                 raise Exception(f"Unknown operation {image_operation.operation}")
 
-
-    def execute_image_operations(self, image_operations: List[ImageOperation]):
+    async def execute_image_operations(self, image_operations: List[ImageOperation]):
         for image_operation in image_operations:
-            self.execute_image_operation(image_operation)
+            await self.execute_image_operation(image_operation)
 
-    def generate_no_change_text_string(self):
-        from openai import OpenAI
-        client = OpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
+    async def generate_no_change_text_string(self):
+        client = AsyncOpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
         image_path = f"/etc/images/{self.userId}/{self.storyId}/{self.images[-1].imageId}.png"
         from ..models.openai_client import image_to_story
-        return image_to_story(client, image_path)
+        return await image_to_story(client, image_path)
 
-    def generate_image_from_sketch_only(self, text="") -> str:
-        from openai import OpenAI
-        client = OpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
+    async def generate_image_from_sketch_only(self, text="") -> str:
+        client = AsyncOpenAI(api_key=os.environ["OPENAI_API_TOKEN"])
         from ..models.openai_client import modify_image
         try:
             image_path = f"/etc/images/{self.userId}/{self.storyId}/{self.images[-1].imageId}.png"
-            return modify_image(client, image_path, text)
+            return await modify_image(client, image_path, text)
         except:
-            return story_to_image(client, text)
+            return await story_to_image(client, text)
 
 class User(Base):
     __tablename__ = 'users'
@@ -257,7 +254,7 @@ class User(Base):
     userName = Column(String)
     accountCreated = Column(String, default=lambda: datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
     story_counter = Column(Integer, default=0)
-    stories = relationship("Story", backref="user", cascade="all, delete-orphan")
+    stories = relationship("Story", backref="user", cascade="all, delete-orphan", lazy="selectin")
 
     def __str__(self):
         return f"Id: {self.userId}\nName: {self.name}\nUsername: {self.userName}\nAccount Created: {self.accountCreated}"

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -1,9 +1,10 @@
 # app/routers/items.py
 
 from fastapi import APIRouter, Depends, HTTPException, status, Query
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
 
-from ..models.db import SessionLocal
+from ..models.db import async_session
 from ..models.structures import User, Story
 from ..models.utils import generate_user_id
 from ..routers.schemas import (
@@ -22,129 +23,138 @@ router = APIRouter(
 )
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+async def get_async_db():
+    async with async_session() as session:
+        yield session
 
-# Endpoints
+
 @router.post("/createNewUser", status_code=status.HTTP_201_CREATED, response_model=UserResponse)
-async def create_new_user(request: CreateUserRequest, db: Session = Depends(get_db)):
+async def create_new_user(request: CreateUserRequest, db: AsyncSession = Depends(get_async_db)):
     user_id = generate_user_id(request.userName)
-    existing_user = db.query(User).filter(User.userId == user_id).first()
+    result = await db.execute(select(User).filter_by(userId=user_id))
+    existing_user = result.scalar_one_or_none()
     if existing_user:
         raise HTTPException(status_code=400, detail=f"User '{request.userName}' already exists")
 
     new_user = User(userId=user_id, name=request.name, userName=request.userName)
     db.add(new_user)
-    db.commit()
-    db.refresh(new_user)
+    await db.commit()
+    await db.refresh(new_user)
     return UserResponse.from_orm(new_user)
 
 
 @router.delete("/deleteUser", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_user(request: DeleteUserRequest, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.userId == request.userId).first()
+async def delete_user(request: DeleteUserRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(User).filter_by(userId=request.userId))
+    user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    db.delete(user)
-    db.commit()
+    await db.delete(user)
+    await db.commit()
 
 
 @router.get("/getUserInformation", response_model=UserResponse)
-async def get_user_information(userId: str, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.userId == userId).first()
+async def get_user_information(userId: str, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(User).filter_by(userId=userId))
+    user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return UserResponse.from_orm(user)
 
 
 @router.get("/getUserInformationByUserName", response_model=UserResponse)
-async def get_user_information_by_user_name(userName: str = Query(...),
-                                            db: Session = Depends(get_db)):
+async def get_user_information_by_user_name(userName: str = Query(...), db: AsyncSession = Depends(get_async_db)):
     user_id = generate_user_id(userName)
-    user = db.query(User).filter(User.userId == user_id).first()
+    result = await db.execute(select(User).filter_by(userId=user_id))
+    user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     return UserResponse.from_orm(user)
 
 
 @router.post("/createNewStory", response_model=StoryBasicInfoResponse)
-async def create_new_story(request: CreateNewStoryRequest, db: Session = Depends(get_db)):
-    user = db.query(User).filter(User.userId == request.userId).first()
+async def create_new_story(request: CreateNewStoryRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(User).filter_by(userId=request.userId))
+    user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     story = user.create_story(story_name=request.storyName)
     db.add(story)
-    db.commit()
-    db.refresh(story)
+    await db.commit()
+    await db.refresh(story)
     return story.to_story_basic_information()
 
 
 @router.post("/setStoryName", response_model=StoryBasicInfoResponse)
-async def set_story_name(request: SetStoryNameRequest, db: Session = Depends(get_db)):
-    story = db.query(Story).filter(Story.storyId == request.storyId).first()
+async def set_story_name(request: SetStoryNameRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(storyId=request.storyId))
+    story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
     story.name = request.storyName
-    db.commit()
-    db.refresh(story)
+    await db.commit()
+    await db.refresh(story)
     return story.to_story_basic_information()
 
 
 @router.delete("/deleteStory", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_story(request: DeleteStoryRequest, db: Session = Depends(get_db)):
-    story = db.query(Story).filter(Story.storyId == request.storyId).first()
+async def delete_story(request: DeleteStoryRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(storyId=request.storyId))
+    story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
-    db.delete(story)
-    db.commit()
+    await db.delete(story)
+    await db.commit()
 
 
 @router.get("/getUserStories", response_model=UserStoriesResponse, operation_id="getUserStories")
-async def get_user_stories(userId: str = Query(...),
-                           maxEntries: int = Query(50),
-                           db: Session = Depends(get_db)
-                           ):
-    stories = db.query(Story).filter(Story.userId == userId).limit(maxEntries).all()
-    return {"stories": reversed([story.to_story_basic_information() for story in stories])}
+async def get_user_stories(userId: str = Query(...), maxEntries: int = Query(50),
+                           db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(userId=userId).limit(maxEntries))
+    stories = result.scalars().all()
+    return {"stories": list(reversed([story.to_story_basic_information() for story in stories]))}
 
 
 @router.get("/getStoryById", response_model=StoryDetailsResponse)
-async def get_story_by_id(userId: str, storyId: str, db: Session = Depends(get_db)):
-    story = db.query(Story).filter(Story.storyId == storyId, Story.userId == userId).first()
+async def get_story_by_id(userId: str, storyId: str, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(storyId=storyId, userId=userId))
+    story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
     return story.to_story_details_response()
 
 
 @router.post("/updateImagesByText", response_model=StoryDetailsResponse)
-async def update_images_by_text(request: UpdateImagesByTextRequest, db: Session = Depends(get_db)):
-    story = db.query(Story).filter(Story.storyId == request.storyId, Story.userId == request.userId).first()
+async def update_images_by_text(request: UpdateImagesByTextRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(storyId=request.storyId, userId=request.userId))
+    story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
-    story.update_images_by_text(request.updatedText)
-    db.commit()
+    await story.update_images_by_text(request.updatedText)
+    await db.commit()
+    await db.refresh(story)
     return story.to_story_details_response()
 
 
 @router.post("/updateTextByImages", response_model=StoryDetailsResponse)
-async def update_text_by_images(request: UpdateTextByImagesRequest, db: Session = Depends(get_db)):
-    story = db.query(Story).filter(Story.storyId == request.storyId, Story.userId == request.userId).first()
+async def update_text_by_images(request: UpdateTextByImagesRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(storyId=request.storyId, userId=request.userId))
+    story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
-    story.update_from_image_operations([op.model_dump() for op in request.imageOperations])
-    db.commit()
+    await story.update_from_image_operations([op.model_dump() for op in request.imageOperations])
+    await db.commit()
+    await db.refresh(story)
     return story.to_story_details_response()
 
 
 @router.post("/uploadImage", response_model=StoryDetailsResponse)
-async def upload_image(request: UploadImageRequest, db: Session = Depends(get_db)):
-    story = db.query(Story).filter(Story.storyId == request.storyId, Story.userId == request.userId).first()
+async def upload_image(request: UploadImageRequest, db: AsyncSession = Depends(get_async_db)):
+    result = await db.execute(select(Story).filter_by(storyId=request.storyId, userId=request.userId))
+    story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
     story.upload_image(request.imageFile)
-    db.commit()
+    await db.commit()
+    await db.refresh(story)
     return story.to_story_details_response()

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -1,5 +1,7 @@
 # app/routers/items.py
 
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -16,6 +18,7 @@ from ..routers.schemas import (
     UpdateTextByImagesRequest, UploadImageRequest
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter(
     prefix="/items",
     tags=["items"],
@@ -130,6 +133,7 @@ async def update_images_by_text(request: UpdateImagesByTextRequest, db: AsyncSes
     story = result.scalar_one_or_none()
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
+    logger.debug("Calling update_images_by_text")
     await story.update_images_by_text(request.updatedText)
     await db.commit()
     await db.refresh(story)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - .:/app
       - ./data:/app/data
       - ./images:/etc/images
-    command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8080 --reload --workers 5
     environment:
       - PROJECT_NAME=HCA FastAPI Backend
       - VERSION=0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.103.1
 uvicorn[standard]==0.23.2
-sqlalchemy==2.0.20
+sqlalchemy[asyncio]
 psycopg2-binary==2.9.7
 python-dotenv==1.0.0
 alembic==1.12.0
@@ -15,4 +15,7 @@ sqlalchemy==2.0.20
 pillow==11.2.1
 openai==1.84.0
 requests==2.32.4
+aiosqlite
+asyncpg
 diff-match-patch==20241021
+aiofiles


### PR DESCRIPTION
This a beta version (alpha ?) still under development :)

Now the server can take up to 5 requests at the same (can be changed) . Every Api call has been adapted to be async (please test and see if I forgot sth/ there are any unexpected events) 

What have been tested:
- can connect into different users and create two images from text (one for each user at the same time :) )
- can connect into different users and create two images; one from text and one from sketch (one for each user at the same time :) )
- cannot generate multiple images for the same user at the same time due to the frontend needing to be updated

@KaiPonel @alsugiliazova please test cases I did not think about, as I am still developing this. @KaiPonel I think this is stable enough to start the development of the frontend :) but I might be wrong.

XOXO

Dumb Mistake: I checked out from the highlight feature branch instead of good old main, if we merge it before this then no problema, otherwise I will get rid of it here but I am lazy :)